### PR TITLE
Limit the schedule for renovate upgrades

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -44,7 +44,7 @@
       "description": "Automerge renovate on a Saturday",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["renovate"],
-      "schedule": ["* * * * 6"]
+      "schedule": ["* 0-3 * * 6"]
     }
   ],
   "poetry": {


### PR DESCRIPTION
Adapt the "Renovate should run each day before 4 am" example:
<https://docs.renovatebot.com/key-concepts/scheduling/#in-repository-schedule-configuration>
